### PR TITLE
Fix docstring typo in list_commands

### DIFF
--- a/cmdmark/main.py
+++ b/cmdmark/main.py
@@ -13,7 +13,7 @@ def list_items(path):
 
 
 def list_commands(data):
-    """List available commands from a parsed 2YAML file."""
+    """List available commands from a parsed YAML file."""
     if "commands" not in data or not isinstance(data["commands"], dict):
         print("No valid commands found in the YAML file.")
         return []


### PR DESCRIPTION
## Summary
- fix a typo in the `list_commands` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6855fa66e3188330ac5b1f1e328c5309