### PR TITLE
Remove alias info from list_commands

### DIFF
--- a/cmdmark/main.py
+++ b/cmdmark/main.py
@@ -19,15 +19,14 @@ def list_commands(data):
         return []
 
     commands = []
-    print(f"id. [alias]:cmd (short description)")
+    print("id. command")
     for idx, (alias, cmd_data) in enumerate(data["commands"].items(), 1):
         if isinstance(cmd_data, dict) and "command" in cmd_data:
-            description = cmd_data.get("description", "No description")
-            cmd = cmd_data.get("command")
-            print(f"{idx}. {alias}:{cmd} ({description})")
+            cmd = cmd_data["command"]
+            print(f"{idx}. {cmd}")
             commands.append(cmd)
         else:
-            print(f"Invalid command format for {cmd}")  # Handles invalid format
+            print(f"Invalid command format for {alias}")
     return commands
 
 


### PR DESCRIPTION
## Summary
- simplify `list_commands` output to display only commands
- restore `.gitignore` and binary artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855fdce05dc8330a72b7294dea52079