### PR TITLE
Ignore git metadata in file listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A CLI tool for managing commands like bookmarks. This Python script provides a s
 *   **YAML Configuration:** Define commands and their descriptions in easy-to-read YAML files.
 *   **Interactive Selection:** Choose categories, files, and commands interactively from the terminal.
 *   **Direct Execution:** Execute selected commands directly within the script.
+*   **Git-Aware:** Git metadata files (e.g., `.git` folders) are ignored when listing categories and YAML files.
 
 
 ## Setup

--- a/cmdmark/main.py
+++ b/cmdmark/main.py
@@ -4,9 +4,17 @@ import yaml
 CONFIG_DIR = os.path.expanduser("~/.command_bookmarks")
 
 
+IGNORED_PREFIX = ".git"
+
+
 def list_items(path):
-    """List folders and YAML files."""
-    items = sorted(os.listdir(path))
+    """List folders and YAML files while skipping git metadata."""
+    items = [
+        item
+        for item in os.listdir(path)
+        if not item.startswith(IGNORED_PREFIX)
+    ]
+    items = sorted(items)
     for idx, item in enumerate(items, 1):
         print(f"{idx}. {item}")
     return items

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 import pytest
 import yaml
-from cmdmark.main import load_yaml  # Adjust import path as needed
+from cmdmark.main import load_yaml, list_items
 
 
 def test_load_yaml_valid(tmp_path):
@@ -27,3 +27,24 @@ def test_load_yaml_invalid(tmp_path):
 def test_load_yaml_file_not_found():
     with pytest.raises(FileNotFoundError):
         load_yaml("nonexistent_file.yml")
+
+
+def test_list_items_ignores_git(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".gitignore").write_text("")
+    (tmp_path / "visible.yml").write_text("")
+    (tmp_path / "dir").mkdir()
+
+    result = list_items(tmp_path)
+    assert ".git" not in result
+    assert ".gitignore" not in result
+    assert sorted(result) == ["dir", "visible.yml"]
+
+
+def test_yaml_listing_skips_git(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "file.yml").write_text("commands: {}")
+    (tmp_path / "not_yaml.txt").write_text("")
+
+    files = [f for f in list_items(tmp_path) if f.endswith(".yml")]
+    assert files == ["file.yml"]


### PR DESCRIPTION
## Summary
- ignore `.git` prefixed entries when listing items
- document that git metadata is skipped
- add tests to ensure git files are ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561410a8608330870c406568efc4b7