### PR TITLE
Add argparse and config directory option

### DIFF
--- a/cmdmark/main.py
+++ b/cmdmark/main.py
@@ -1,7 +1,8 @@
+import argparse
 import os
 import yaml
 
-CONFIG_DIR = os.path.expanduser("~/.command_bookmarks")
+DEFAULT_CONFIG_DIR = os.path.expanduser("~/.command_bookmarks")
 
 
 IGNORED_PREFIX = ".git"
@@ -9,11 +10,7 @@ IGNORED_PREFIX = ".git"
 
 def list_items(path):
     """List folders and YAML files while skipping git metadata."""
-    items = [
-        item
-        for item in os.listdir(path)
-        if not item.startswith(IGNORED_PREFIX)
-    ]
+    items = [item for item in os.listdir(path) if not item.startswith(IGNORED_PREFIX)]
     items = sorted(items)
     for idx, item in enumerate(items, 1):
         print(f"{idx}. {item}")
@@ -56,15 +53,32 @@ def load_yaml(filepath):
         return yaml.safe_load(f)
 
 
-def main():
-    if not os.path.exists(CONFIG_DIR):
-        print(f"Config folder not found: {CONFIG_DIR}")
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Manage command bookmarks stored in YAML files."
+    )
+    parser.add_argument(
+        "-c",
+        "--config-dir",
+        default=DEFAULT_CONFIG_DIR,
+        help="Path to configuration directory (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config_dir = os.path.expanduser(args.config_dir)
+
+    if not os.path.exists(config_dir):
+        print(f"Config folder not found: {config_dir}")
         return
 
     print("=== Categories ===")
-    categories = list_items(CONFIG_DIR)
+    categories = list_items(config_dir)
     selected_category = select_item(categories)
-    category_path = os.path.join(CONFIG_DIR, selected_category)
+    category_path = os.path.join(config_dir, selected_category)
 
     print(f"\n=== {selected_category} Files ===")
     files = [f for f in list_items(category_path) if f.endswith(".yml")]


### PR DESCRIPTION
## Summary
- add argparse parsing in `cmdmark/main.py`
- support `--config-dir` option with default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685718653ba48330a72fa30d78b34082