### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add CI workflow using Python 3.12
- run tests on push and pull request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857187861488330b3a7dfa9f805f092