### PR TITLE
Move pytest to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "A CLI tool for managing commands like bookmarks"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["pytest (>=8.3.5,<9.0.0)", "pyaml (>=25.5.0,<26.0.0)", "pyyaml (>=6.0.2,<7.0.0)"]
+dependencies = ["pyaml (>=25.5.0,<26.0.0)", "pyyaml (>=6.0.2,<7.0.0)"]
 
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
@@ -17,6 +17,9 @@ Homepage = "https://github.com/abc1199281/cmdmark"
 
 [tool.poetry.scripts]
 cmdmark = "cmdmark.main:main"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.3.5,<9.0.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
## Summary
- keep pytest only as a development requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571871c0a08330b51cadf2d4ecd79d