### PR TITLE
Support config dir env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ A CLI tool for managing commands like bookmarks. This Python script provides a s
     ```
     This will install `cmdmark` and its dependency, `PyYAML`. This project requires Python 3.12 or higher.
 
-2.  **Configuration Directory:** The script uses a configuration directory located at `~/.command_bookmarks`. Make sure that the directory exists. You may create some sub-directories in `~/.command_bookmarks` to categorize your commands, and create yml files to store the relative commands.
+2.  **Configuration Directory:** The script uses a configuration directory located at `~/.command_bookmarks`. Make sure that the directory exists. You may create some sub-directories in `~/.command_bookmarks` to categorize your commands, and create yml files to store the relative commands. You can override this location by setting the environment variable `CMDMARK_CONFIG_DIR`.
+
+    For example, in your shell configuration (e.g. `~/.bashrc` or `~/.zshrc`):
+
+    ```bash
+    export CMDMARK_CONFIG_DIR="$HOME/my_cmdmarks"
+    ```
 
 3.  **YAML Files:** Create YAML files within the configuration directory (or its subdirectories) to define your commands.  The structure of the YAML file is as follows:
 

--- a/cmdmark/main.py
+++ b/cmdmark/main.py
@@ -4,6 +4,7 @@ import yaml
 from . import __version__
 
 DEFAULT_CONFIG_DIR = os.path.expanduser("~/.command_bookmarks")
+ENV_CONFIG_DIR = "CMDMARK_CONFIG_DIR"
 
 
 IGNORED_PREFIX = ".git"
@@ -68,7 +69,7 @@ def parse_args():
     parser.add_argument(
         "-c",
         "--config-dir",
-        default=DEFAULT_CONFIG_DIR,
+        default=os.environ.get(ENV_CONFIG_DIR, DEFAULT_CONFIG_DIR),
         help="Path to configuration directory (default: %(default)s)",
     )
     return parser.parse_args()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
-from cmdmark.main import load_yaml, list_items
+import sys
+from cmdmark.main import load_yaml, list_items, parse_args, ENV_CONFIG_DIR, DEFAULT_CONFIG_DIR
 
 
 def test_load_yaml_valid(tmp_path):
@@ -48,3 +49,11 @@ def test_yaml_listing_skips_git(tmp_path):
 
     files = [f for f in list_items(tmp_path) if f.endswith(".yml")]
     assert files == ["file.yml"]
+
+
+def test_parse_args_uses_env(monkeypatch):
+    custom = "/tmp/custom_cfg"
+    monkeypatch.setenv(ENV_CONFIG_DIR, custom)
+    monkeypatch.setattr(sys, "argv", ["cmdmark"])
+    args = parse_args()
+    assert args.config_dir == custom


### PR DESCRIPTION
## Summary
- default config dir can be overridden by `CMDMARK_CONFIG_DIR`
- document the new environment variable in README
- test env var logic in `parse_args`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685737c9e0ec8330b1da6585879ba855