### PR TITLE
Use subprocess.run for command execution

### DIFF
--- a/cmdmark/main.py
+++ b/cmdmark/main.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 import yaml
 from . import __version__
 
@@ -92,6 +93,26 @@ def parse_args(argv: list[str] | None = None):
     return parser.parse_args(argv)
 
 
+def run_command(command: str) -> None:
+    """Execute the given command with ``subprocess.run``.
+
+    Parameters
+    ----------
+    command:
+        Command string to execute.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the command exits with a non-zero status.
+    """
+    try:
+        subprocess.run(command, shell=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed with exit code {exc.returncode}")
+        raise
+
+
 def main() -> None:
     args = parse_args()
     config_dir = os.path.expanduser(args.config_dir)
@@ -114,7 +135,6 @@ def main() -> None:
     selected_file = select_item(files)
     file_path = os.path.join(category_path, selected_file)
 
-
     print(f"\n=== {selected_file} Commands ===")
     data = load_yaml(file_path)
     if "commands" not in data:
@@ -125,7 +145,7 @@ def main() -> None:
     command = select_item(command_keys)
 
     print(f"\nExecuting: {command}\n")
-    os.system(command)
+    run_command(command)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,16 @@
 import pytest
 import yaml
 import sys
-from cmdmark.main import load_yaml, list_items, parse_args, list_commands, ENV_CONFIG_DIR, DEFAULT_CONFIG_DIR
+import subprocess
+from cmdmark.main import (
+    load_yaml,
+    list_items,
+    parse_args,
+    list_commands,
+    ENV_CONFIG_DIR,
+    DEFAULT_CONFIG_DIR,
+    run_command,
+)
 
 
 def test_load_yaml_valid(tmp_path):
@@ -49,3 +58,14 @@ def test_yaml_listing_skips_git(tmp_path):
 
     files = [f for f in list_items(tmp_path) if f.endswith(".yml")]
     assert files == ["file.yml"]
+
+
+def test_run_command_failure():
+    with pytest.raises(subprocess.CalledProcessError):
+        run_command("false")
+
+
+def test_run_command_success(capsys):
+    run_command("echo hello")
+    captured = capsys.readouterr()
+    assert "Command failed" not in captured.out


### PR DESCRIPTION
## Summary
- execute shell commands using `subprocess.run`
- surface command failures by re-raising `CalledProcessError`
- test successful and failing command execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575eb1b93483308984b0946c0463c1