### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install .[test]
+
+CMD ["pytest", "-q"]

--- a/README.md
+++ b/README.md
@@ -120,3 +120,19 @@ cmdmark
 ```
 
 Select a category (e.g. `git`), choose a YAML file such as `basic.yml`, and then pick a command like `status`. `cmdmark` will run `git status` right away.
+
+## Docker
+
+The repository includes a `Dockerfile` so you can build a containerized
+environment for running the tests or invoking the CLI.
+
+```bash
+# Build the image
+docker build -t cmdmark .
+
+# Run the test suite
+docker run --rm cmdmark
+
+# Or start the CLI (override the default command)
+docker run --rm -it cmdmark cmdmark
+```


### PR DESCRIPTION
## Summary
- add a simple Dockerfile for Python 3.12
- document how to build and use the Docker container

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dd873cb7c8330a0834556722dd56f