### PR TITLE
Configure pre-commit with linting and type checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-PyYAML]

--- a/README.md
+++ b/README.md
@@ -136,3 +136,13 @@ docker run --rm cmdmark
 # Or start the CLI (override the default command)
 docker run --rm -it cmdmark cmdmark
 ```
+
+## Development
+
+This repository uses [pre-commit](https://pre-commit.com/) to run code formatting, linting, and type checks.
+Install the git hook scripts and run all checks with:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,14 +1,9 @@
 import pytest
 import yaml
-import sys
 import subprocess
 from cmdmark.main import (
     load_yaml,
     list_items,
-    parse_args,
-    list_commands,
-    ENV_CONFIG_DIR,
-    DEFAULT_CONFIG_DIR,
     run_command,
 )
 


### PR DESCRIPTION
## Summary
- add pre-commit config using ruff, black, and mypy
- document development workflow using pre-commit
- clean up test imports to satisfy new lint checks

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eac1bf9a48330a14c665ebbabfaa9