### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-PyYAML]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ cmdmark
 
 Select a category (e.g. `git`), choose a YAML file such as `basic.yml`, and then pick a command like `status`. `cmdmark` will run `git status` right away.
 
+## Development
+
+This project uses [pre-commit](https://pre-commit.com/) for linting and type checks.
+Install the hooks with:
+
+```bash
+pre-commit install
+```
+
+Run all checks with:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Docker
 
 The repository includes a `Dockerfile` so you can build a containerized


### PR DESCRIPTION
## Summary
- add pre-commit configuration with ruff, black, and mypy
- document pre-commit usage in README

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec40d20f483309ea2c97a43140619