### PR TITLE
ci: run pip-audit in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[test]
+          pip install pip-audit
+      - name: Run pip-audit
+        run: pip-audit
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- add pip-audit dependency scan to CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pip-audit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff7409aac8330a3ceee9ee5a8602d