### PR TITLE
Add MkDocs documentation and Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs
+      - name: Build docs
+        run: mkdocs build --strict
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .dist*
 dist*
 .venv*
+site/
+.coverage

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# cmdmark Documentation
+
+`cmdmark` is a command-line tool for managing command bookmarks stored in YAML files.
+
+This site provides an overview of the project, usage examples, and an API reference for
+its main modules.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,11 @@
+# Modules
+
+## `cmdmark.main`
+
+- `list_items(path)` – list folders and YAML files while skipping Git metadata.
+- `list_commands(data, verbose=False)` – display available commands from a YAML file.
+- `select_item(items)` – prompt the user to select an entry by number.
+- `load_yaml(filepath)` – load commands from a YAML file.
+- `parse_args(argv=None)` – parse command line arguments.
+- `run_command(command)` – execute a command via `subprocess.run`.
+- `main()` – entry point used by the `cmdmark` console script.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,17 @@
+# Usage
+
+`cmdmark` scans a directory of YAML files that group useful commands. Each
+category is a folder containing one or more YAML files with a `commands`
+section.
+
+By default, the configuration directory is `~/.command_bookmarks`. You can
+change it with the `CMDMARK_CONFIG_DIR` environment variable or the
+`--config-dir` option.
+
+```bash
+# list categories and run a command
+cmdmark
+
+# include command descriptions while listing
+cmdmark --verbose
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: cmdmark
+nav:
+  - Home: index.md
+  - Usage: usage.md
+  - Modules: modules.md
+docs_dir: docs


### PR DESCRIPTION
## Summary
- add MkDocs config and documentation pages
- document key modules and command usage
- build and deploy docs on push via GitHub Actions

## Testing
- `pytest -q`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68912d87afb88330a6de4265202e1bfc