### PR TITLE
ci: add linting and type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,14 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install .[test] ruff mypy
           pip install pip-audit
+      - name: Run ruff
+        run: ruff check .
+      - name: Check formatting
+        run: ruff format --check .
+      - name: Run mypy
+        run: mypy .
       - name: Run pip-audit
         run: pip-audit
       - name: Run tests


### PR DESCRIPTION
## Summary
- install ruff and mypy in CI workflow
- run ruff checks, formatting check, and mypy before tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68912d6076bc83308a666fa8f888a552